### PR TITLE
Bump to version 1.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    ougai-formatters-customizable (1.0.0)
-      ougai (~> 1.7, >= 1.7.0)
+    ougai-formatters-customizable (1.0.1)
+      ougai (~> 1.8, >= 1.8.4)
 
 GEM
   remote: https://rubygems.org/
@@ -13,8 +13,8 @@ GEM
     docile (1.3.1)
     hirb (0.7.3)
     json (2.1.0)
-    oj (3.10.5)
-    ougai (1.8.3)
+    oj (3.10.6)
+    ougai (1.8.4)
       oj (~> 3.10)
     rake (13.0.1)
     rspec (3.8.0)
@@ -54,4 +54,4 @@ DEPENDENCIES
   simplecov-console (~> 0.4.2)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/lib/ougai/formatters/customizable/version.rb
+++ b/lib/ougai/formatters/customizable/version.rb
@@ -3,6 +3,6 @@
 module Ougai
   module Formatters
     # Customizable extension version
-    CUSTOMIZABLE_VERSION = '1.0.0'
+    CUSTOMIZABLE_VERSION = '1.0.1'
   end
 end

--- a/ougai-formatters-customizable.gemspec
+++ b/ougai-formatters-customizable.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # runtimes dependencies
-  spec.add_runtime_dependency 'ougai', '~>1.7', '>= 1.7.0'
+  spec.add_runtime_dependency 'ougai', '~>1.8', '>= 1.8.4'
 
   # development specific dependencies. Used when +gem install --dev your_gem+
   spec.add_development_dependency 'amazing_print', '~> 1.0'


### PR DESCRIPTION
## Purpose

Following #4, a [new release is required](https://github.com/Al-un/ougai-formatters-customizable/pull/4#issuecomment-617182586).

## Changes

- Bump to version 1.0.1
- To align with ougai library version with `amazing_print` usage, minimum ougai version is now `1.8.4` ([link](https://github.com/tilfin/ougai/issues/103#issuecomment-613251137))